### PR TITLE
Reworked to work with the steam new email format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This is a nodejs package for steam email auth.
 It uses IMAP to fetch the latest emails and gives you the last key it could get.
 
+This fork has been updated to support the new email format steam uses (URL verification instead of code).
+
 ## Installation
 It is as easy as always:
 
@@ -10,9 +12,13 @@ It is as easy as always:
 npm install steam-email-auth
 ```
 
+A reminder you may need to allow gmail for 'insecure apps' and possibly login to the account on the same IP in a browser for it to work.
 
 ## Example Usage
 ```
+var SteamEmailAuth = require('steam-email-auth');
+var request = require('request');
+
 var auth = new SteamEmailAuth({
     user: 'user@gmail.com',
     password: "gmailpass",
@@ -21,18 +27,22 @@ var auth = new SteamEmailAuth({
     tls: true
 });
 
-auth.fetchLastAuthCode({}, function (key) {
-    console.log("Key: "+ key)
-});
-```
-
-If you use the email for multiple accounts, you should prefer this call:
-
-```
-auth.fetchLastAuthCode({
-    username: "username here!"
-}, function (key) {
-    console.log("Key: "+ key)
+auth.fetchLastAuthCode({username: "steamusername"}, function (url) { 
+    var options = {
+        url: url,
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36'
+        }
+	};
+	 
+	function callback(error, response, body) {
+		if (error) {
+			console.log("There was an error requesting the URL: " + error.message);
+		} else {
+			console.log("URL requested successfully");
+		}
+	}
+	request(options, callback); //run request on URL
 });
 ```
 
@@ -43,6 +53,5 @@ auth.fetchLastAuthCode({
 Creates a new IMAP connection and returns the guard key it has found.
 * `options` - an object representing the configuration. Can be {}.
   * `username` (optional) - The username (login) whick key we are searching. Use this if you have multiple steam accounts on this email.
-  * `type` (optional) - "web", "computer" or nothing. To filter what type of auth you need (web is also mobile).
-* `callback(key)`  - a function, getting the guard key as first argument.
-  * `key` - The guard key. NULL if none has been found.
+* `callback(url)`  - a function, getting the url as first argument.
+  * `url` - The url. NULL if none has been found.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a nodejs package for steam email auth.
 It uses IMAP to fetch the latest emails and gives you the last key it could get.
 
-This fork has been updated to support the new email format steam uses (URL verification instead of code).
+This fork has been updated to support the new email format steam uses (URL verification instead of code).  
 The previous is depreciated.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ It uses IMAP to fetch the latest emails and gives you the last key it could get.
 This fork has been updated to support the new email format steam uses (URL verification instead of code).
 
 ## Installation
-It is as easy as always:
 
-```
-npm install steam-email-auth
-```
+Install is to clone this fork, unless the main npm package gets updated.
 
 A reminder you may need to allow gmail for 'insecure apps' and possibly login to the account on the same IP in a browser for it to work.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a nodejs package for steam email auth.
 It uses IMAP to fetch the latest emails and gives you the last key it could get.
 
 This fork has been updated to support the new email format steam uses (URL verification instead of code).
+The previous is depreciated.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ auth.fetchLastAuthCode({username: "steamusername"}, function (url) {
 	var options = {
         	url: url,
         	headers: {
-            	'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36'
+            		'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36'
         	}
 	};
 	 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ var auth = new SteamEmailAuth({
 });
 
 auth.fetchLastAuthCode({username: "steamusername"}, function (url) { 
-    var options = {
-        url: url,
-        headers: {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36'
-        }
+	var options = {
+        	url: url,
+        	headers: {
+            	'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36'
+        	}
 	};
 	 
 	function callback(error, response, body) {

--- a/example.js
+++ b/example.js
@@ -1,4 +1,5 @@
-﻿var SteamEmailAuth = require("./index.js");
+var SteamEmailAuth = require('steam-email-auth');
+var request = require('request');
 
 var auth = new SteamEmailAuth({
     user: 'user@gmail.com',
@@ -8,15 +9,20 @@ var auth = new SteamEmailAuth({
     tls: true
 });
 
-auth.fetchLastAuthCode({
-    username: "username"
-}, function (key) {
-    console.log("Key: "+ key)
+auth.fetchLastAuthCode({username: "steamusername"}, function (url) { 
+	var options = {
+        	url: url,
+        	headers: {
+            		'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36'
+        	}
+	};
+	 
+	function callback(error, response, body) {
+		if (error) {
+			console.log("There was an error requesting the URL: " + error.message);
+		} else {
+			console.log("URL requested successfully");
+		}
+	}
+	request(options, callback); //run request on URL
 });
-
-
-
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "steam-email-auth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "steam-email-auth",
   "main": "index.js",
-  "author": "Mijago <coding.mijago+nodejs@gmail.com>",
+  "author": "jfx <notemail@jfx.space>",
   "dependencies": {
     "imap": "^0.8.16"
   },
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Mijago/node-steam-email-auth.git"
+    "url": "git+https://github.com/itsjfx/node-steam-email-auth.git"
   },
   "keywords": [
     "steam",
@@ -21,7 +21,7 @@
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Mijago/node-steam-email-auth/issues"
+    "url": "https://github.com/itsjfx/node-steam-email-auth/issues"
   },
-  "homepage": "https://github.com/Mijago/node-steam-email-auth#readme"
+  "homepage": "https://github.com/itsjfx/node-steam-email-auth#readme"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "author": "Mijago <coding.mijago+nodejs@gmail.com>",
   "dependencies": {
-    "imap": "0.8.16"
+    "imap": "^0.8.16"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Callback now returns the URL from the steam email, this is done through string manipulation (splits and pops).
Not sure if there's a more efficient URL parsing library in node.js but this seemed to work well.

The URL can be requested using request to verify the email, however I decided that returning the URL would be adequate as the user can choose how they can verify the request.